### PR TITLE
stack name not allow to includes underline

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -3,7 +3,7 @@ data "local_file" "cloudformation_template" {
 }
 
 resource "aws_cloudformation_stack" "chatbot_slack_configuration" {
-  name = "chatbot-slack-configuration-${var.configuration_name}"
+  name = "chatbot-slack-configuration-${replace(var.configuration_name, "_", "-")}"
 
   template_body = data.local_file.cloudformation_template.content
 


### PR DESCRIPTION
I can't use Chatbot configuration name as CloudFormation stack name, so I'll convert it.

Chatbot ConfigurationName: `The name can have up to 128 characters. Valid characters: a-z, A-Z, 0-9, and - _`
CloudFormation Stack name: `Stack name can include letters (A-Z and a-z), numbers (0-9), and dashes (-).`


## Internal Ticket: 

### Notes

* Terraform docs will be auto-generated by a Github action

### Testing

* Run `make alpha scope=<major|minor|patch>` to tag and publish an alpha version
* Update the `version = "..."` of your module usage to your published alpha version (eg. `version = "v2.2.0-alpha.1+9f2630a"`)
* Run `make plan` in the keller terraform workspace

### Checklist

* [ ] Run `make changelog scope=<major|minor|patch>`
* [ ] CHANGELOG.md: Adjust change notes as necessary

### Publishing

* [ ] Merge this Pull Request
* [ ] Run `git checkout master; git pull; make publish scope=<major|minor|patch>`
